### PR TITLE
removal of unnecessary variable

### DIFF
--- a/src/beada.c
+++ b/src/beada.c
@@ -13,6 +13,7 @@
 #include <drm/drm_damage_helper.h>
 #include <drm/drm_drv.h>
 #include <drm/drm_edid.h>
+#include <drm/drm_fbdev_generic.h>
 #include <drm/drm_fb_helper.h>
 #include <drm/drm_file.h>
 #include <drm/drm_format_helper.h>
@@ -204,12 +205,13 @@ static int beada_misc_request(struct beada_device *beada)
 static int beada_buf_copy(void *dst, const struct iosys_map *map, struct drm_framebuffer *fb, struct drm_rect *clip)
 {
 	int ret;
+	unsigned int pitch=0;
 
 	ret = drm_gem_fb_begin_cpu_access(fb, DMA_FROM_DEVICE);
 	if (ret)
 		return ret;
 
-	drm_fb_xrgb8888_to_rgb565(dst, map->vaddr, fb, clip, false);
+	drm_fb_xrgb8888_to_rgb565(dst, &pitch, map->vaddr, fb, clip, false);
 
 	drm_gem_fb_end_cpu_access(fb, DMA_FROM_DEVICE);
 

--- a/src/beada.c
+++ b/src/beada.c
@@ -74,7 +74,6 @@ struct beada_device {
 
 	unsigned int	width;
 	unsigned int	height;
-	unsigned int	margin;
 	unsigned int	width_mm;
 	unsigned int	height_mm;
 	unsigned char	*cmd_buf;
@@ -157,11 +156,10 @@ static int beada_misc_request(struct beada_device *beada)
 {
 	int ret;
 	unsigned int len, len1;
-	int width, height, margin, width_mm, height_mm;
+	int width, height, width_mm, height_mm;
 	char *model;
 
 	len = CMD_SIZE;
-	margin = 0;
 
 	// prepare statuslink command
 	ret = fillSLGetInfo(beada->cmd_buf, &len);
@@ -291,7 +289,6 @@ static int beada_misc_request(struct beada_device *beada)
 		model = "5";
 		width  = 800;
 		height = 480;
-		margin = 0;
 		width_mm = 108;
 		height_mm = 65;	
 		break;
@@ -299,7 +296,6 @@ static int beada_misc_request(struct beada_device *beada)
 
 	beada->width = width;
 	beada->height = height;
-	beada->margin = margin;
 	beada->model = model;
 	beada->width_mm = width_mm;
 	beada->height_mm = height_mm;
@@ -723,7 +719,7 @@ static int beada_usb_probe(struct usb_interface *interface,
 	beada_mode_config_setup(beada);
 	beada_edid_setup(beada);
 	
-	beada->draw_buf = drmm_kmalloc(&beada->dev, beada->height * beada->width * RGB565_BPP / 8 + beada->margin, GFP_KERNEL);
+	beada->draw_buf = drmm_kmalloc(&beada->dev, beada->height * beada->width * RGB565_BPP / 8, GFP_KERNEL);
 	if (!beada->draw_buf) {
 		DRM_DEV_ERROR(&beada->udev->dev, "beada->draw_buf init failed\n");
 		goto err_put_device;

--- a/src/beada.c
+++ b/src/beada.c
@@ -332,6 +332,10 @@ static void beada_fb_mark_dirty(struct drm_framebuffer *fb, const struct iosys_m
 	int idx, len, height, width, ret;
 	char fmtstr[256] = {0};
 
+	height = rect->y2 - rect->y1;
+	width = rect->x2 - rect->x1;
+	len = height * width * RGB565_BPP / 8;
+
 	if (!drm_dev_enter(fb->dev, &idx))
 		return;
 
@@ -345,9 +349,6 @@ static void beada_fb_mark_dirty(struct drm_framebuffer *fb, const struct iosys_m
 		(beada->old_rect_x2 == rect->x2) &&
 		(beada->old_rect_y2 == rect->y2)) ) {
 
-		height = rect->y2 - rect->y1;
-		width = rect->x2 - rect->x1;
-		len = height * width * RGB565_BPP / 8;
 		snprintf(fmtstr, sizeof(fmtstr), "video/x-raw, format=RGB16, height=%d, width=%d, framerate=0/1", height, width);
 		ret = beada_send_tag(beada, (const char *)fmtstr);
 		if (ret < 0)
@@ -356,7 +357,7 @@ static void beada_fb_mark_dirty(struct drm_framebuffer *fb, const struct iosys_m
 
 	ret = usb_bulk_msg(beada->udev, usb_sndbulkpipe(beada->udev, beada->data_snd_ept), beada->draw_buf,
 			    len, NULL, PANELLINK_MAX_DELAY);
-
+	
 	beada->old_rect_x1 = rect->x1;
 	beada->old_rect_y1 = rect->y1;
 	beada->old_rect_x2 = rect->x2;

--- a/src/beada.c
+++ b/src/beada.c
@@ -56,7 +56,7 @@
 #define RGB565_BPP			16
 #define CMD_TIMEOUT			msecs_to_jiffies(200)
 #define DATA_TIMEOUT			msecs_to_jiffies(1000)
-#define PANELLINK_MAX_DELAY		msecs_to_jiffies(1000)
+#define PANELLINK_MAX_DELAY		msecs_to_jiffies(2000)
 #define CMD_SIZE			512*4
 
 struct beada_device {

--- a/src/beada.c
+++ b/src/beada.c
@@ -370,6 +370,56 @@ err_msg:
 	drm_dev_exit(idx);
 }
 
+static void beada_fb_mark_dirty_1(struct drm_framebuffer *fb, const struct iosys_map *map, struct drm_rect *rect)
+{
+	struct beada_device *beada = to_beada(fb->dev);
+	int idx, len, height, width, ret;
+	char fmtstr[256] = {0};
+	struct drm_rect rect_form;
+
+	rect_form.x1 = 0;
+	rect_form.y1 = 0;
+	rect_form.x2 = beada->width;
+	rect_form.y2 = beada->height;
+	
+	height = beada->height;
+	width = beada->width;
+	len = height * width * RGB565_BPP / 8;
+
+	if (!drm_dev_enter(fb->dev, &idx))
+		return;
+
+	ret = beada_buf_copy(&beada->dest_map, map, fb, &rect_form);
+	if (ret)
+		goto err_msg;
+
+	/* send a new tag if rect size changed */
+	if (!((beada->old_rect_x1 == rect->x1) &&
+		(beada->old_rect_y1 == rect->y1) &&
+		(beada->old_rect_x2 == rect->x2) &&
+		(beada->old_rect_y2 == rect->y2)) ) {
+
+		snprintf(fmtstr, sizeof(fmtstr), "video/x-raw, format=RGB16, height=%d, width=%d, framerate=0/1", height, width);
+		ret = beada_send_tag(beada, (const char *)fmtstr);
+		if (ret < 0)
+			goto err_msg;
+		
+		beada->old_rect_x1 = rect->x1;
+		beada->old_rect_y1 = rect->y1;
+		beada->old_rect_x2 = rect->x2;
+		beada->old_rect_y2 = rect->y2;
+	}
+
+	ret = usb_bulk_msg(beada->udev, usb_sndbulkpipe(beada->udev, beada->data_snd_ept), beada->draw_buf,
+			    len, NULL, PANELLINK_MAX_DELAY);
+	
+err_msg:
+	if (ret)
+		dev_err_once(fb->dev->dev, "Failed to update display %d\n", ret);
+
+	drm_dev_exit(idx);
+}
+
 /* ------------------------------------------------------------------ */
 /* beada connector						      */
 
@@ -475,7 +525,7 @@ static void beada_pipe_enable(struct drm_simple_display_pipe *pipe,
 		.y2 = fb->height,
 	};
 
-	beada_fb_mark_dirty(fb, &shadow_plane_state->data[0], &rect);
+	beada_fb_mark_dirty_1(fb, &shadow_plane_state->data[0], &rect);
 }
 
 static void beada_pipe_disable(struct drm_simple_display_pipe *pipe)
@@ -496,7 +546,7 @@ static void beada_pipe_update(struct drm_simple_display_pipe *pipe,
 		return;
 
 	if (drm_atomic_helper_damage_merged(old_state, state, &rect))
-		beada_fb_mark_dirty(fb, &shadow_plane_state->data[0], &rect);
+		beada_fb_mark_dirty_1(fb, &shadow_plane_state->data[0], &rect);
 }
 
 static const struct drm_simple_display_pipe_funcs beada_pipe_funcs = {

--- a/src/beada.c
+++ b/src/beada.c
@@ -219,17 +219,17 @@ static int beada_misc_request(struct beada_device *beada)
 		break;
 	case MODEL_3:
 		model = "3";
-		width = 480;
-		height = 320;
-		width_mm = 62;
-		height_mm = 40;
+		height = 480;
+		width = 320;
+		height_mm = 62;
+		width_mm = 40;
 		break;
 	case MODEL_4:
 		model = "4";
-		width = 800;
-		height = 480;
-		width_mm = 94;
-		height_mm = 56;
+		height = 800;
+		width = 480;
+		height_mm = 94;
+		width_mm = 56;
 		break;
 	case MODEL_3C:
 		model = "3C";
@@ -261,10 +261,10 @@ static int beada_misc_request(struct beada_device *beada)
 		break;
 	case MODEL_6:
 		model = "6";
-		width = 1280;
-		height = 480;
-		width_mm = 161;
-		height_mm = 60;
+		height = 1280;
+		width = 480;
+		height_mm = 161;
+		width_mm = 60;
 		break;
 	case MODEL_6C:
 		model = "6C";
@@ -396,7 +396,7 @@ static void beada_fb_mark_dirty_1(struct drm_framebuffer *fb, const struct iosys
 		(beada->old_rect.x2 == 0) &&
 		(beada->old_rect.y2 == 0)) ) {
 
-		snprintf(fmtstr, sizeof(fmtstr), "video/x-raw, format=RGB16, height=%d, width=%d, framerate=0/1", height, width);
+		snprintf(fmtstr, sizeof(fmtstr), "image/x-raw, format=BGR16, height=%d, width=%d, framerate=0/1", height, width);
 		ret = beada_send_tag(beada, (const char *)fmtstr);
 		if (ret < 0)
 			goto err_msg;
@@ -596,7 +596,7 @@ static const struct drm_driver beada_drm_driver = {
 
 	.fops		 = &beada_fops,
 	DRM_GEM_SHMEM_DRIVER_OPS,
-//.gem_prime_import = beada_gem_prime_import,
+	.gem_prime_import = beada_gem_prime_import,
 };
 
 static const struct drm_mode_config_funcs beada_mode_config_funcs = {

--- a/src/beada.c
+++ b/src/beada.c
@@ -37,10 +37,12 @@
 #define DRIVER_MAJOR		1
 #define DRIVER_MINOR		0
 
-#define MODEL_3			3
-#define MODEL_4			4
-#define MODEL_5			0
-#define MODEL_6			2
+
+#define MODEL_5		0
+#define MODEL_7		1
+#define MODEL_6		2
+#define MODEL_3		3
+#define MODEL_4		4
 #define MODEL_5C		10
 #define MODEL_5S		11
 #define MODEL_7C		12
@@ -48,14 +50,14 @@
 #define MODEL_4C		14
 #define MODEL_6C		15
 #define MODEL_6S		16
-#define MODEL_2			17
+#define MODEL_2		17
 #define MODEL_2W		18 
 
-#define RGB565_BPP				16
-#define CMD_TIMEOUT				msecs_to_jiffies(200)
+#define RGB565_BPP			16
+#define CMD_TIMEOUT			msecs_to_jiffies(200)
 #define DATA_TIMEOUT			msecs_to_jiffies(1000)
 #define PANELLINK_MAX_DELAY		msecs_to_jiffies(1000)
-#define CMD_SIZE				512*4
+#define CMD_SIZE			512*4
 
 struct beada_device {
 	struct drm_device				dev;
@@ -79,10 +81,10 @@ struct beada_device {
 	unsigned char	*draw_buf;
 	struct iosys_map dest_map;
 
-	int				old_rect_x1;
-	int				old_rect_y1;
-	int				old_rect_x2;
-	int				old_rect_y2;
+	int		old_rect_x1;
+	int		old_rect_y1;
+	int		old_rect_x2;
+	int		old_rect_y2;
 
 	unsigned int	misc_rcv_ept;
 	unsigned int	misc_snd_ept;
@@ -133,19 +135,19 @@ static int beada_send_tag(struct beada_device *beada, const char* cmd)
 
 	len = CMD_SIZE;
 
-    /* prepare tag header */
-	ret = fillPLStart(beada->cmd_buf, &len, cmd);	
+	/* prepare tag header */
+	ret = fillPLStart(beada->draw_buf, &len, cmd);	
 	if (ret) {
 		DRM_DEV_ERROR(&beada->udev->dev, "fillPLStart() error %d\n", ret);
 		return -EIO;
 	}
 
-	HexDump(beada->cmd_buf, len, beada->cmd_buf);
+	HexDump(beada->draw_buf, len, beada->draw_buf);
 
 	/* send request */
 	ret = usb_bulk_msg(beada->udev,
-			usb_sndbulkpipe(beada->udev, beada->misc_snd_ept),
-			beada->cmd_buf, len, &len1, CMD_TIMEOUT);
+			usb_sndbulkpipe(beada->udev, beada->data_snd_ept),
+			beada->draw_buf, len, &len1, CMD_TIMEOUT);
 
 	if (ret || len != len1) {
 		DRM_DEV_ERROR(&beada->udev->dev, "usb_bulk_msg() error %d\n", ret);
@@ -159,8 +161,10 @@ static int beada_misc_request(struct beada_device *beada)
 {
 	int ret;
 	unsigned int len, len1;
+	int width, height, margin, width_mm, height_mm;
+	char *model;
 
-    len = CMD_SIZE;
+	len = CMD_SIZE;
 
 	// prepare statuslink command
 	ret = fillSLGetInfo(beada->cmd_buf, &len);
@@ -201,6 +205,108 @@ static int beada_misc_request(struct beada_device *beada)
 		return -EIO;
 	}
 
+	switch (beada->info.os_version) {
+	case MODEL_2:
+		model = "2";
+		width = 480;
+		height = 480;
+		width_mm = 53;
+		height_mm = 53;
+		break;
+	case MODEL_2W:
+		model = "2W";
+		width = 480;
+		height = 480;
+		width_mm = 70;
+		height_mm = 70;
+		break;
+	case MODEL_3:
+		model = "3";
+		width = 480;
+		height = 320;
+		width_mm = 62;
+		height_mm = 40;
+		break;
+	case MODEL_4:
+		model = "4";
+		width = 800;
+		height = 480;
+		width_mm = 94;
+		height_mm = 56;
+		break;
+	case MODEL_3C:
+		model = "3C";
+		width = 480;
+		height = 320;
+		width_mm = 62;
+		height_mm = 40;
+		break;
+	case MODEL_4C:
+		model = "4C";
+		width = 800;
+		height = 480;
+		width_mm = 94;
+		height_mm = 56;
+		break;
+	case MODEL_5:
+		model = "5";
+		width = 800;
+		height = 480;
+		width_mm = 108;
+		height_mm = 65;
+		break;
+	case MODEL_5S:
+		model = "5S";
+		width = 800;
+		height = 480;
+		width_mm = 108;
+		height_mm = 65;
+		break;
+	case MODEL_6:
+		model = "6";
+		width = 1280;
+		height = 480;
+		width_mm = 161;
+		height_mm = 60;
+		break;
+	case MODEL_6C:
+		model = "6C";
+		width = 1280;
+		height = 480;
+		width_mm = 161;
+		height_mm = 60;
+		break;
+	case MODEL_6S:
+		model = "6S";
+		width = 1280;
+		height = 480;
+		width_mm = 161;
+		height_mm = 60;
+		break;
+	case MODEL_7C:
+		model = "7C";
+		width = 800;
+		height = 480;
+		width_mm = 62;
+		height_mm = 110;
+		break;
+	default:
+		model = "5";
+		width  = 800;
+		height = 480;
+		margin = 0;
+		width_mm = 108;
+		height_mm = 65;	
+		break;
+	}
+
+	beada->width = width;
+	beada->height = height;
+	beada->margin = margin;
+	beada->model = model;
+	beada->width_mm = width_mm;
+	beada->height_mm = height_mm;
+	
 	return 0;
 }
 
@@ -449,117 +555,12 @@ static const struct drm_mode_config_funcs beada_mode_config_funcs = {
 static void beada_mode_config_setup(struct beada_device *beada)
 {
 	struct drm_device *dev = &beada->dev;
-	int width, height, margin, width_mm, height_mm;
-	char *model;
-
-	switch (beada->info.os_version) {
-	case MODEL_2:
-		model = "2";
-		width = 480;
-		height = 480;
-		width_mm = 53;
-		height_mm = 53;
-		break;
-	case MODEL_2W:
-		model = "2W";
-		width = 480;
-		height = 480;
-		width_mm = 70;
-		height_mm = 70;
-		break;
-	case MODEL_3:
-		model = "3";
-		width = 480;
-		height = 320;
-		width_mm = 62;
-		height_mm = 40;
-		break;
-	case MODEL_4:
-		model = "4";
-		width = 800;
-		height = 480;
-		width_mm = 94;
-		height_mm = 56;
-		break;
-	case MODEL_3C:
-		model = "3C";
-		width = 480;
-		height = 320;
-		width_mm = 62;
-		height_mm = 40;
-		break;
-	case MODEL_4C:
-		model = "4C";
-		width = 800;
-		height = 480;
-		width_mm = 94;
-		height_mm = 56;
-		break;
-	case MODEL_5:
-		model = "5";
-		width = 800;
-		height = 480;
-		width_mm = 108;
-		height_mm = 65;
-		break;
-
-	case MODEL_5S:
-		model = "5S";
-		width = 800;
-		height = 480;
-		width_mm = 108;
-		height_mm = 65;
-		break;
-	case MODEL_6:
-		model = "6";
-		width = 1280;
-		height = 480;
-		width_mm = 161;
-		height_mm = 60;
-		break;
-	case MODEL_6C:
-		model = "6C";
-		width = 1280;
-		height = 480;
-		width_mm = 161;
-		height_mm = 60;
-		break;
-	case MODEL_6S:
-		model = "6S";
-		width = 1280;
-		height = 480;
-		width_mm = 161;
-		height_mm = 60;
-		break;
-	case MODEL_7C:
-		model = "7C";
-		width = 800;
-		height = 480;
-		width_mm = 62;
-		height_mm = 110;
-		break;
-	default:
-		model = "5";
-		width  = 800;
-		height = 4800;
-		margin = 0;
-		width_mm = 108;
-		height_mm = 65;	
-		break;
-	}
-
-	beada->width = width;
-	beada->height = height;
-	beada->margin = margin;
-	beada->model = model;
-	beada->width_mm = width_mm;
-	beada->height_mm = height_mm;
 
 	dev->mode_config.funcs = &beada_mode_config_funcs;
-	dev->mode_config.min_width = width;
-	dev->mode_config.max_width = width;
-	dev->mode_config.min_height = height;
-	dev->mode_config.max_height = height;
+	dev->mode_config.min_width = beada->width;
+	dev->mode_config.max_width = beada->width;
+	dev->mode_config.min_height = beada->height;
+	dev->mode_config.max_height = beada->height;
 }
 
 static int beada_edid_block_checksum(u8 *raw_edid)
@@ -622,7 +623,6 @@ static int beada_usb_probe(struct usb_interface *interface,
 	struct beada_device *beada;
 	struct drm_device *dev;
 	int ret;
-	unsigned char *buf;
 
 	/*
 	 * The beada presents itself to the system as 2 usb mass-storage

--- a/src/beada.c
+++ b/src/beada.c
@@ -596,7 +596,7 @@ static const struct drm_driver beada_drm_driver = {
 
 	.fops		 = &beada_fops,
 	DRM_GEM_SHMEM_DRIVER_OPS,
-	.gem_prime_import = beada_gem_prime_import,
+//.gem_prime_import = beada_gem_prime_import,
 };
 
 static const struct drm_mode_config_funcs beada_mode_config_funcs = {

--- a/src/beada.c
+++ b/src/beada.c
@@ -13,7 +13,6 @@
 #include <drm/drm_damage_helper.h>
 #include <drm/drm_drv.h>
 #include <drm/drm_edid.h>
-#include <drm/drm_fbdev_generic.h>
 #include <drm/drm_fb_helper.h>
 #include <drm/drm_file.h>
 #include <drm/drm_format_helper.h>
@@ -205,13 +204,12 @@ static int beada_misc_request(struct beada_device *beada)
 static int beada_buf_copy(void *dst, const struct iosys_map *map, struct drm_framebuffer *fb, struct drm_rect *clip)
 {
 	int ret;
-	unsigned int pitch=0;
 
 	ret = drm_gem_fb_begin_cpu_access(fb, DMA_FROM_DEVICE);
 	if (ret)
 		return ret;
 
-	drm_fb_xrgb8888_to_rgb565(dst, &pitch, map->vaddr, fb, clip, false);
+	drm_fb_xrgb8888_to_rgb565(dst, map->vaddr, fb, clip, false);
 
 	drm_gem_fb_end_cpu_access(fb, DMA_FROM_DEVICE);
 

--- a/src/beada.c
+++ b/src/beada.c
@@ -213,7 +213,7 @@ static int beada_buf_copy(void *dst, const struct iosys_map *map, struct drm_fra
 	if (ret)
 		return ret;
 
-	drm_fb_xrgb8888_to_rgb565((struct iosys_map *)dst, &pitch, map->vaddr, fb, clip, false);
+	drm_fb_xrgb8888_to_rgb565((struct iosys_map *)dst, &pitch, map, fb, clip, false);
 
 	drm_gem_fb_end_cpu_access(fb, DMA_FROM_DEVICE);
 


### PR DESCRIPTION
margin can be removed. It is always 0 and only used to increase buffer size while allocating.
But x + 0 is always x, so it can be safely removed as un-used variable being just a burden
to beada_device struct.